### PR TITLE
SLING-8104 Avoid magic when merging features

### DIFF
--- a/src/main/java/org/apache/sling/feature/builder/BuilderContext.java
+++ b/src/main/java/org/apache/sling/feature/builder/BuilderContext.java
@@ -29,10 +29,6 @@ import java.util.Map;
  */
 public class BuilderContext {
 
-    enum ArtifactMergeAlgorithm {
-        LATEST, HIGHEST
-    }
-
     /** The required feature provider */
     private final FeatureProvider provider;
 
@@ -42,10 +38,10 @@ public class BuilderContext {
     private final Map<String, Map<String,String>> extensionConfiguration = new HashMap<>();
     private final List<MergeHandler> mergeExtensions = new ArrayList<>();
     private final List<PostProcessHandler> postProcessExtensions = new ArrayList<>();
+    private final List<String> artifactsOverrides = new ArrayList<>();
     private final Map<String,String> variables = new HashMap<>();
     private final Map<String,String> frameworkProperties = new HashMap<>();
 
-    private ArtifactMergeAlgorithm merge = ArtifactMergeAlgorithm.HIGHEST;
 
     /**
      * Create a new context
@@ -94,6 +90,17 @@ public class BuilderContext {
     }
 
     /**
+     * Add overrides for artifact clashes
+     *
+     * @param overrides The overwrites
+     * @return The builder context
+     */
+    public BuilderContext addArtifactsOverrides(final List<String> overrides) {
+        this.artifactsOverrides.addAll(overrides);
+        return this;
+    }
+
+    /**
      * Add merge extensions
      *
      * @param extensions A list of merge extensions
@@ -112,17 +119,6 @@ public class BuilderContext {
      */
     public BuilderContext addPostProcessExtensions(final PostProcessHandler... extensions) {
         postProcessExtensions.addAll(Arrays.asList(extensions));
-        return this;
-    }
-
-    /**
-     * Set the merge algorithm
-     *
-     * @param alg The algorithm
-     * @return The builder context
-     */
-    public BuilderContext setMergeAlgorithm(final ArtifactMergeAlgorithm alg) {
-        this.merge = alg;
         return this;
     }
 
@@ -152,8 +148,12 @@ public class BuilderContext {
         return this.artifactProvider;
     }
 
+    List<String> getArtifactOverrides() {
+        return this.artifactsOverrides;
+    }
+
     Map<String,String> getVariablesOverwrites() {
-        return  this.variables;
+        return this.variables;
     }
 
     Map<String,String> getFrameworkPropertiesOverwrites() {
@@ -166,10 +166,6 @@ public class BuilderContext {
      */
     FeatureProvider getFeatureProvider() {
         return this.provider;
-    }
-
-    ArtifactMergeAlgorithm getMergeAlgorithm() {
-        return this.merge;
     }
 
     /**
@@ -196,11 +192,11 @@ public class BuilderContext {
     BuilderContext clone(final FeatureProvider featureProvider) {
         final BuilderContext ctx = new BuilderContext(featureProvider);
         ctx.setArtifactProvider(this.artifactProvider);
+        ctx.artifactsOverrides.addAll(this.artifactsOverrides);
         ctx.variables.putAll(this.variables);
         ctx.frameworkProperties.putAll(this.frameworkProperties);
         ctx.mergeExtensions.addAll(mergeExtensions);
         ctx.postProcessExtensions.addAll(postProcessExtensions);
-        ctx.merge = this.merge;
         return ctx;
     }
 }

--- a/src/main/java/org/apache/sling/feature/builder/BuilderContext.java
+++ b/src/main/java/org/apache/sling/feature/builder/BuilderContext.java
@@ -68,23 +68,23 @@ public class BuilderContext {
     }
 
     /**
-     * Add overwrites for the variables
+     * Add overrides for the variables
      *
-     * @param vars The overwrites
+     * @param vars The overrides
      * @return The builder context
      */
-    public BuilderContext addVariablesOverwrites(final Map<String,String> vars) {
+    public BuilderContext addVariablesOverrides(final Map<String,String> vars) {
         this.variables.putAll(vars);
         return this;
     }
 
     /**
-     * Add overwrites for the framework properties
+     * Add overrides for the framework properties
      *
-     * @param props The overwrites
+     * @param props The overrides
      * @return The builder context
      */
-    public BuilderContext addFrameworkPropertiesOverwrites(final Map<String,String> props) {
+    public BuilderContext addFrameworkPropertiesOverrides(final Map<String,String> props) {
         this.frameworkProperties.putAll(props);
         return this;
     }
@@ -92,7 +92,7 @@ public class BuilderContext {
     /**
      * Add overrides for artifact clashes
      *
-     * @param overrides The overwrites
+     * @param overrides The overrides
      * @return The builder context
      */
     public BuilderContext addArtifactsOverrides(final List<String> overrides) {
@@ -152,11 +152,11 @@ public class BuilderContext {
         return this.artifactsOverrides;
     }
 
-    Map<String,String> getVariablesOverwrites() {
+    Map<String,String> getVariablesOverrides() {
         return this.variables;
     }
 
-    Map<String,String> getFrameworkPropertiesOverwrites() {
+    Map<String,String> getFrameworkPropertiesOverrides() {
         return this.frameworkProperties;
     }
 

--- a/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
+++ b/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
@@ -45,8 +45,8 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonStructure;
 import javax.json.JsonValue;
-import javax.json.JsonWriter;
 import javax.json.JsonValue.ValueType;
+import javax.json.JsonWriter;
 
 /**
  * Utility methods for the builders
@@ -76,7 +76,7 @@ class BuilderUtil {
         return null;
     }
 
-    private static void mergeWithContextOverwrite(String type, Map<String,String> target, Map<String,String> source, Iterable<Map.Entry<String,String>> context) {
+    private static void mergeWithContextOverride(String type, Map<String,String> target, Map<String,String> source, Iterable<Map.Entry<String,String>> context) {
         Map<String,String> result = new HashMap<>();
         for (Map.Entry<String, String> entry : target.entrySet()) {
             result.put(entry.getKey(), contains(entry.getKey(), context) ? get(entry.getKey(), context) : entry.getValue());
@@ -91,7 +91,7 @@ class BuilderUtil {
                     String targetValue = target.get(entry.getKey());
                     if (targetValue != null) {
                         if (!value.equals(targetValue)) {
-                            throw new IllegalStateException(String.format("Can't merge %s '%s' defined twice (as '%s' v.s. '%s') and not overwritten.", type, entry.getKey(), value, targetValue));
+                            throw new IllegalStateException(String.format("Can't merge %s '%s' defined twice (as '%s' v.s. '%s') and not overridden.", type, entry.getKey(), value, targetValue));
                         }
                     }
                     else {
@@ -109,8 +109,8 @@ class BuilderUtil {
 
     // variables
     static void mergeVariables(Map<String,String> target, Map<String,String> source, BuilderContext context) {
-        mergeWithContextOverwrite("Variable", target, source,
-                (null != context) ? context.getVariablesOverwrites().entrySet() : null);
+        mergeWithContextOverride("Variable", target, source,
+                (null != context) ? context.getVariablesOverrides().entrySet() : null);
     }
 
     /**
@@ -237,8 +237,8 @@ class BuilderUtil {
 
     // framework properties (add/merge)
     static void mergeFrameworkProperties(final Map<String,String> target, final Map<String,String> source, BuilderContext context) {
-        mergeWithContextOverwrite("Property", target, source,
-                context != null ? context.getFrameworkPropertiesOverwrites().entrySet() : null);
+        mergeWithContextOverride("Property", target, source,
+                context != null ? context.getFrameworkPropertiesOverrides().entrySet() : null);
     }
 
     // requirements (add)

--- a/src/main/java/org/apache/sling/feature/builder/FeatureBuilder.java
+++ b/src/main/java/org/apache/sling/feature/builder/FeatureBuilder.java
@@ -330,8 +330,8 @@ public abstract class FeatureBuilder {
             // and merge the current feature over the included feature into the result
             merge(result, feature, context, Collections.singletonList("*:*:LATEST"));
 
-            // set the origin of the included artifacts and configurations to the resulting feature
-            setOrigins(result, includedFeature);
+            // set the origin of the artifacts and configurations included and part of the resulting feature back to null
+            resetOrigins(result, includedFeature);
         }
 
         result.setAssembled(true);
@@ -469,26 +469,30 @@ public abstract class FeatureBuilder {
     }
 
     // Set the origin of elements coming from an included feature to the target feature
-    private static void setOrigins(Feature feature, Feature includedFeature) {
+    private static void resetOrigins(Feature feature, Feature includedFeature) {
+        String currentID = feature.getId().toMvnId();
         String includedID = includedFeature.getId().toMvnId();
 
         // As the feature is a prototype, set the origins to the target where it's going to
         for (Artifact a : feature.getBundles()) {
             Map<String, String> md = a.getMetadata();
-            if (includedID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE)))
-                md.put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, feature.getId().toMvnId());
+            if (currentID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE))
+                    || includedID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE)))
+                md.remove(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE);
         }
         for (Configuration c : feature.getConfigurations()) {
             Dictionary<String, Object> props = c.getProperties();
-            if (includedID.equals(props.get(Configuration.PROP_ORIGINAL__FEATURE)))
-                props.put(Configuration.PROP_ORIGINAL__FEATURE, feature.getId().toMvnId());
+            if (currentID.equals(props.get(Configuration.PROP_ORIGINAL__FEATURE))
+                    || includedID.equals(props.get(Configuration.PROP_ORIGINAL__FEATURE)))
+                props.remove(Configuration.PROP_ORIGINAL__FEATURE);
         }
         for (Extension e : feature.getExtensions()) {
             if (ExtensionType.ARTIFACTS == e.getType()) {
                 for (Artifact a : e.getArtifacts()) {
                     Map<String, String> md = a.getMetadata();
-                    if (includedID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE)))
-                        md.put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, feature.getId().toMvnId());
+                    if (currentID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE))
+                            || includedID.equals(md.get(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE)))
+                        md.remove(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE);
                 }
             }
         }

--- a/src/test/java/org/apache/sling/feature/builder/BuilderUtilTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/BuilderUtilTest.java
@@ -22,7 +22,6 @@ import org.apache.sling.feature.Bundles;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
 import org.apache.sling.feature.Feature;
-import org.apache.sling.feature.builder.BuilderContext.ArtifactMergeAlgorithm;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -30,6 +29,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +105,8 @@ public class BuilderUtilTest {
 
         final Feature orgFeat = new Feature(new ArtifactId("gid", "aid", "123", null, null));
 
-        BuilderUtil.mergeBundles(target, source, orgFeat, ArtifactMergeAlgorithm.HIGHEST);
+        List<String> overrides = Arrays.asList("g:a:HIGHEST", "g:b:HIGHEST");
+        BuilderUtil.mergeBundles(target, source, orgFeat, overrides);
 
         final List<Map.Entry<Integer, Artifact>> result = getBundles(target);
         assertEquals(3, result.size());
@@ -133,7 +134,8 @@ public class BuilderUtilTest {
 
         final Feature orgFeat = new Feature(new ArtifactId("gid", "aid", "123", null, null));
 
-        BuilderUtil.mergeBundles(target, source, orgFeat, ArtifactMergeAlgorithm.LATEST);
+        List<String> overrides = Arrays.asList("g:a:LATEST", "g:b:LATEST");
+        BuilderUtil.mergeBundles(target, source, orgFeat, overrides);
 
         final List<Map.Entry<Integer, Artifact>> result = getBundles(target);
         assertEquals(3, result.size());
@@ -151,7 +153,8 @@ public class BuilderUtilTest {
         source.add(createBundle("g/a/1.1", 2));
 
         final Feature orgFeat = new Feature(new ArtifactId("gid", "aid", "123", null, null));
-        BuilderUtil.mergeBundles(target, source, orgFeat, ArtifactMergeAlgorithm.LATEST);
+        List<String> overrides = Arrays.asList("g:a:LATEST", "g:b:LATEST");
+        BuilderUtil.mergeBundles(target, source, orgFeat, overrides);
 
         final List<Map.Entry<Integer, Artifact>> result = getBundles(target);
         assertEquals(1, result.size());
@@ -171,7 +174,7 @@ public class BuilderUtilTest {
         source.add(createBundle("g/f/2.5", 3));
 
         final Feature orgFeat = new Feature(new ArtifactId("gid", "aid", "123", null, null));
-        BuilderUtil.mergeBundles(target, source, orgFeat, ArtifactMergeAlgorithm.LATEST);
+        BuilderUtil.mergeBundles(target, source, orgFeat, new ArrayList<>());
 
         final List<Map.Entry<Integer, Artifact>> result = getBundles(target);
         assertEquals(6, result.size());
@@ -191,11 +194,11 @@ public class BuilderUtilTest {
         source.add(createBundle("g/b/1.0", 1));
 
         final Feature orgFeat = new Feature(new ArtifactId("gid", "aid", "123", "c1", "slingfeature"));
-        BuilderUtil.mergeBundles(target, source, orgFeat, ArtifactMergeAlgorithm.LATEST);
+        BuilderUtil.mergeBundles(target, source, orgFeat, new ArrayList<>());
 
         final Bundles target2 = new Bundles();
         final Feature orgFeat2 = new Feature(new ArtifactId("g", "a", "1", null, null));
-        BuilderUtil.mergeBundles(target2, target, orgFeat2, ArtifactMergeAlgorithm.LATEST);
+        BuilderUtil.mergeBundles(target2, target, orgFeat2, new ArrayList<>());
 
         List<Entry<Integer, Artifact>> result = getBundles(target2);
         assertEquals(2, result.size());
@@ -214,7 +217,7 @@ public class BuilderUtilTest {
 
         source.setJSON("[\"source1\",\"source2\"]");
 
-        BuilderUtil.mergeExtensions(target, source, null, ArtifactMergeAlgorithm.HIGHEST);
+        BuilderUtil.mergeExtensions(target, source, null, new ArrayList<>());
 
         assertEquals(target.getJSON(), "[\"target1\",\"target2\",\"source1\",\"source2\"]");
 
@@ -306,7 +309,7 @@ public class BuilderUtilTest {
         Feature ft = new Feature(ArtifactId.fromMvnId("g:t:1"));
 
         assertEquals("Precondition", 0, ft.getExtensions().size());
-        BuilderUtil.mergeExtensions(ft, fs, ArtifactMergeAlgorithm.LATEST, ctx, true);
+        BuilderUtil.mergeExtensions(ft, fs, ctx, new ArrayList<>());
         assertEquals(1, ft.getExtensions().size());
 
         Extension actual = ft.getExtensions().get(0);
@@ -330,7 +333,7 @@ public class BuilderUtilTest {
         ft.getExtensions().add(et);
 
         assertEquals("Precondition", 1, ft.getExtensions().size());
-        BuilderUtil.mergeExtensions(ft, fs, ArtifactMergeAlgorithm.LATEST, ctx, true);
+        BuilderUtil.mergeExtensions(ft, fs, ctx, new ArrayList<>());
         assertEquals(1, ft.getExtensions().size());
 
         Extension actual = ft.getExtensions().get(0);
@@ -357,7 +360,7 @@ public class BuilderUtilTest {
         Feature ft = new Feature(ArtifactId.fromMvnId("g:t:1"));
 
         assertEquals("Precondition", 0, ft.getExtensions().size());
-        BuilderUtil.mergeExtensions(ft, fs, ArtifactMergeAlgorithm.LATEST, ctx, true);
+        BuilderUtil.mergeExtensions(ft, fs, ctx, new ArrayList<>());
         assertEquals(1, ft.getExtensions().size());
 
         Extension actual = ft.getExtensions().get(0);
@@ -382,7 +385,7 @@ public class BuilderUtilTest {
         ft.getExtensions().add(et);
 
         assertEquals("Precondition", 1, ft.getExtensions().size());
-        BuilderUtil.mergeExtensions(ft, fs, ArtifactMergeAlgorithm.LATEST, ctx, true);
+        BuilderUtil.mergeExtensions(ft, fs, ctx, new ArrayList<>());
         assertEquals(1, ft.getExtensions().size());
 
         Extension actual = ft.getExtensions().get(0);
@@ -391,6 +394,80 @@ public class BuilderUtilTest {
         JsonReader ar = Json.createReader(new StringReader(actual.getJSON()));
         JsonReader er = Json.createReader(new StringReader(expected));
         assertEquals(er.readObject(), ar.readObject());
+    }
+
+    @Test public void testSelectArtifactOverrideAll() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Arrays.asList("gid:aid2:1", "gid:aid:ALL ");
+        assertEquals(Arrays.asList(a1, a2), BuilderUtil.selectArtifactOverride(a1, a2, overrides));
+    }
+
+    @Test public void testSelectArtifactOverrideIdenticalNeedsNoRule() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        assertEquals(Collections.singletonList(a1), BuilderUtil.selectArtifactOverride(a1, a2, Collections.emptyList()));
+    }
+
+    @Test public void testSelectArtifactOverride1() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Collections.singletonList("gid:aid:1");
+        assertEquals(Collections.singletonList(a1), BuilderUtil.selectArtifactOverride(a1, a2, overrides));
+    }
+
+    @Test public void testSelectArtifactOverride2() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Collections.singletonList("gid:aid:2");
+        assertEquals(Collections.singletonList(a2), BuilderUtil.selectArtifactOverride(a1, a2, overrides));
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSelectArtifactOverride3() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Collections.singletonList("gid:aid:3");
+        BuilderUtil.selectArtifactOverride(a1, a2, overrides);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSelectArtifactOverrideDifferentGroupID() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("aid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Collections.singletonList("gid:aid:2");
+        BuilderUtil.selectArtifactOverride(a1, a2, overrides);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSelectArtifactOverrideDifferentArtifactID() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:gid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        List<String> overrides = Collections.singletonList("gid:aid:2");
+        BuilderUtil.selectArtifactOverride(a1, a2, overrides);
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testSelectArtifactOverrideDifferentNoRule() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2"));
+        BuilderUtil.selectArtifactOverride(a1, a2, Collections.emptyList());
+    }
+
+    @Test public void testSelectArtifactOverrideHigest() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1.1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2.0.1"));
+        List<String> overrides = Collections.singletonList("gid:aid:HIGHEST");
+        assertEquals(Collections.singletonList(a2), BuilderUtil.selectArtifactOverride(a1, a2, overrides));
+        assertEquals(Collections.singletonList(a2), BuilderUtil.selectArtifactOverride(a2, a1, overrides));
+    }
+
+    @Test public void testSelectArtifactOverrideLatest() {
+        Artifact a1 = new Artifact(ArtifactId.fromMvnId("gid:aid:1.1"));
+        Artifact a2 = new Artifact(ArtifactId.fromMvnId("gid:aid:2.0.1"));
+        List<String> overrides = Collections.singletonList("gid:aid:LATEST");
+        assertEquals(Collections.singletonList(a2), BuilderUtil.selectArtifactOverride(a1, a2, overrides));
+        assertEquals(Collections.singletonList(a1), BuilderUtil.selectArtifactOverride(a2, a1, overrides));
     }
 
     @SafeVarargs

--- a/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
@@ -762,7 +762,7 @@ public class FeatureBuilderTest {
             {
                 return null;
             }
-                }).addVariablesOverwrites(override), aFeature, bFeature);
+                }).addVariablesOverrides(override), aFeature, bFeature);
 
         Map<String,String> vars = new HashMap<>();
         vars.putAll(kvMapA);
@@ -783,7 +783,7 @@ public class FeatureBuilderTest {
                 {
                     return null;
                 }
-                    }).addVariablesOverwrites(override), aFeature, bFeature);
+                    }).addVariablesOverrides(override), aFeature, bFeature);
             fail("Excepted merge exception");
         } catch (IllegalStateException expected) {}
 
@@ -796,7 +796,7 @@ public class FeatureBuilderTest {
             {
                 return null;
             }
-                }).addVariablesOverwrites(override), aFeature, bFeature);
+                }).addVariablesOverrides(override), aFeature, bFeature);
 
         vars = new HashMap<>();
         vars.putAll(kvMapA);
@@ -815,7 +815,7 @@ public class FeatureBuilderTest {
             {
                 return null;
             }
-                }).addVariablesOverwrites(override), aFeature, bFeature);
+                }).addVariablesOverrides(override), aFeature, bFeature);
 
         vars.put("var2", null);
         assertTrue(cFeature.getVariables().equals(vars));

--- a/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
@@ -323,17 +323,16 @@ public class FeatureBuilderTest {
         result.getVariables().put("varx", "myvalx");
         result.setInclude(null);
         result.getFrameworkProperties().put("bar", "X");
-        Map.Entry<String, String> md2 = new AbstractMap.SimpleEntry<String, String>("org-feature", "g:a:1");
+        Map.Entry<String, String> md2 = new AbstractMap.SimpleEntry<String, String>(
+                "org-feature", "org.apache.sling:test-feature:1.1");
         result.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-bar/4.5.6", 3, md2));
-
-        for (final Configuration c : result.getConfigurations()) {
-            c.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, base.getId().toMvnId());
-        }
 
         final Configuration co3 = new Configuration("org.apache.sling.foo");
         co3.getProperties().put("prop", "value");
-        co3.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, i1.getId().toMvnId());
         result.getConfigurations().add(co3);
+        for (final Configuration c : result.getConfigurations()) {
+            c.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, base.getId().toMvnId());
+        }
 
         BuilderContext builderContext = new BuilderContext(provider);
 
@@ -366,7 +365,7 @@ public class FeatureBuilderTest {
         b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:3");
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -387,15 +386,15 @@ public class FeatureBuilderTest {
         b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b0);
         Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
-        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b1.setStartOrder(4);
         result.getBundles().add(b1);
         Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:2"));
-        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b2.setStartOrder(8);
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -420,7 +419,7 @@ public class FeatureBuilderTest {
         b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b1);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -449,7 +448,7 @@ public class FeatureBuilderTest {
         b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 

--- a/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -295,16 +294,14 @@ public class FeatureBuilderTest {
         final Artifact a1 = new Artifact(ArtifactId.parse("org.apache.sling/oak-server/1.0.0"));
         a1.getMetadata().put(Artifact.KEY_START_ORDER, "1");
         a1.getMetadata().put("hash", "4632463464363646436");
-        a1.getMetadata().put("org-feature", "org.apache.sling:test-feature:1.1");
         base.getBundles().add(a1);
-        Map.Entry<String, String> md = new AbstractMap.SimpleEntry<String, String>("org-feature", "org.apache.sling:test-feature:1.1");
-        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/application-bundle/2.0.0", 1, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/another-bundle/2.1.0", 1, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-xyz/1.2.3", 2, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewversion_low/1", 5, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewversion_high/5", 5, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewstartlevel/1", 10, md));
-        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewstartlevelandversion/2", 10, md));
+        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/application-bundle/2.0.0", 1));
+        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/another-bundle/2.1.0", 1));
+        base.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-xyz/1.2.3", 2));
+        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewversion_low/1", 5));
+        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewversion_high/5", 5));
+        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewstartlevel/1", 10));
+        base.getBundles().add(BuilderUtilTest.createBundle("group/testnewstartlevelandversion/2", 10));
 
         final Configuration co1 = new Configuration("my.pid");
         co1.getProperties().put("foo", 5L);
@@ -323,21 +320,13 @@ public class FeatureBuilderTest {
         result.getVariables().put("varx", "myvalx");
         result.setInclude(null);
         result.getFrameworkProperties().put("bar", "X");
-        Map.Entry<String, String> md2 = new AbstractMap.SimpleEntry<String, String>(
-                "org-feature", "org.apache.sling:test-feature:1.1");
-        result.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-bar/4.5.6", 3, md2));
-
+        result.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-bar/4.5.6", 3));
         final Configuration co3 = new Configuration("org.apache.sling.foo");
         co3.getProperties().put("prop", "value");
         result.getConfigurations().add(co3);
-        for (final Configuration c : result.getConfigurations()) {
-            c.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, base.getId().toMvnId());
-        }
-
-        BuilderContext builderContext = new BuilderContext(provider);
 
         // assemble
-        final Feature assembled = FeatureBuilder.assemble(base, builderContext);
+        final Feature assembled = FeatureBuilder.assemble(base, new BuilderContext(provider));
 
         // and test
         equals(result, assembled);
@@ -356,16 +345,12 @@ public class FeatureBuilderTest {
 
         Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
         Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
-        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b0);
         Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
-        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b1);
         Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:3"));
-        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -383,18 +368,14 @@ public class FeatureBuilderTest {
 
         Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
         Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
-        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b0);
         Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
-        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b1.setStartOrder(4);
         result.getBundles().add(b1);
         Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:2"));
-        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b2.setStartOrder(8);
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -413,13 +394,10 @@ public class FeatureBuilderTest {
 
         Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
         Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
-        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b0);
         Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
-        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b1);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 
@@ -439,16 +417,12 @@ public class FeatureBuilderTest {
 
         Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
         Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
-        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b0);
         Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
-        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b1);
         Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:3"));
-        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         result.getBundles().add(b2);
         Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
-        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
         b3.setStartOrder(4);
         result.getBundles().add(b3);
 

--- a/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
@@ -16,23 +16,6 @@
  */
 package org.apache.sling.feature.builder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.felix.utils.resource.CapabilityImpl;
 import org.apache.felix.utils.resource.RequirementImpl;
 import org.apache.sling.feature.Artifact;
@@ -46,6 +29,23 @@ import org.apache.sling.feature.Include;
 import org.junit.Test;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FeatureBuilderTest {
 
@@ -69,6 +69,25 @@ public class FeatureBuilderTest {
         f1.getConfigurations().add(c1);
 
         FEATURES.put(f1.getId().toMvnId(), f1);
+    }
+
+    static {
+        final Feature f2 = new Feature(ArtifactId.parse("g/a/2"));
+
+        f2.getBundles().add(BuilderUtilTest.createBundle("group/testmulti/1", 4));
+        f2.getBundles().add(BuilderUtilTest.createBundle("group/testmulti/2", 8));
+        f2.getBundles().add(BuilderUtilTest.createBundle("group/someart/1.2.3", 4));
+
+        FEATURES.put(f2.getId().toMvnId(), f2);
+    }
+
+    static {
+        final Feature f2 = new Feature(ArtifactId.parse("g/a/3"));
+
+        f2.getBundles().add(BuilderUtilTest.createBundle("group/testmulti/2", 8));
+        f2.getBundles().add(BuilderUtilTest.createBundle("group/someart/1.2.3", 4));
+
+        FEATURES.put(f2.getId().toMvnId(), f2);
     }
 
     private final FeatureProvider provider = new FeatureProvider() {
@@ -306,15 +325,134 @@ public class FeatureBuilderTest {
         result.getFrameworkProperties().put("bar", "X");
         Map.Entry<String, String> md2 = new AbstractMap.SimpleEntry<String, String>("org-feature", "g:a:1");
         result.getBundles().add(BuilderUtilTest.createBundle("org.apache.sling/foo-bar/4.5.6", 3, md2));
+
+        for (final Configuration c : result.getConfigurations()) {
+            c.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, base.getId().toMvnId());
+        }
+
         final Configuration co3 = new Configuration("org.apache.sling.foo");
         co3.getProperties().put("prop", "value");
         co3.getProperties().put(Configuration.PROP_ORIGINAL__FEATURE, i1.getId().toMvnId());
         result.getConfigurations().add(co3);
 
+        BuilderContext builderContext = new BuilderContext(provider);
+
         // assemble
-        final Feature assembled = FeatureBuilder.assemble(base, new BuilderContext(provider));
+        final Feature assembled = FeatureBuilder.assemble(base, builderContext);
 
         // and test
+        equals(result, assembled);
+    }
+
+    @Test public void testSingleIncludeMultiVersion() {
+        Feature base = new Feature(ArtifactId.fromMvnId("g:tgtart:1"));
+        Include i1 = new Include(ArtifactId.fromMvnId("g:a:3"));
+        base.setInclude(i1);
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("g:myart:1")));
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("group:testmulti:1")));
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("group:testmulti:3")));
+
+        BuilderContext builderContext = new BuilderContext(provider);
+        Feature assembled = FeatureBuilder.assemble(base, builderContext);
+
+        Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
+        Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
+        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b0);
+        Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
+        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b1);
+        Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:3"));
+        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b2);
+        Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:3");
+        b3.setStartOrder(4);
+        result.getBundles().add(b3);
+
+        equals(result, assembled);
+    }
+
+    @Test public void testSingleIncludeMultiVersion2() {
+        Feature base = new Feature(ArtifactId.fromMvnId("g:tgtart:1"));
+        Include i1 = new Include(ArtifactId.fromMvnId("g:a:2"));
+        base.setInclude(i1);
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("g:myart:1")));
+
+        BuilderContext builderContext = new BuilderContext(provider);
+        Feature assembled = FeatureBuilder.assemble(base, builderContext);
+
+        Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
+        Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
+        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b0);
+        Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
+        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b1.setStartOrder(4);
+        result.getBundles().add(b1);
+        Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:2"));
+        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b2.setStartOrder(8);
+        result.getBundles().add(b2);
+        Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.setStartOrder(4);
+        result.getBundles().add(b3);
+
+        equals(result, assembled);
+    }
+
+    @Test public void testSingleIncludeMultiVersion3() {
+        Feature base = new Feature(ArtifactId.fromMvnId("g:tgtart:1"));
+        Include i1 = new Include(ArtifactId.fromMvnId("g:a:2"));
+        base.setInclude(i1);
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("g:myart:1")));
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("group:testmulti:1")));
+
+        BuilderContext builderContext = new BuilderContext(provider);
+        Feature assembled = FeatureBuilder.assemble(base, builderContext);
+
+        Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
+        Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
+        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b0);
+        Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
+        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b1);
+        Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.setStartOrder(4);
+        result.getBundles().add(b3);
+
+        equals(result, assembled);
+    }
+
+    @Test public void testSingleIncludeMultiVersion4() {
+        Feature base = new Feature(ArtifactId.fromMvnId("g:tgtart:1"));
+        Include i1 = new Include(ArtifactId.fromMvnId("g:a:2"));
+        base.setInclude(i1);
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("g:myart:1")));
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("group:testmulti:1")));
+        base.getBundles().add(new Artifact(ArtifactId.fromMvnId("group:testmulti:3")));
+
+        BuilderContext builderContext = new BuilderContext(provider);
+        Feature assembled = FeatureBuilder.assemble(base, builderContext);
+
+        Feature result = new Feature(ArtifactId.parse("g:tgtart:1"));
+        Artifact b0 = new Artifact(ArtifactId.fromMvnId("g:myart:1"));
+        b0.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b0);
+        Artifact b1 = new Artifact(ArtifactId.fromMvnId("group:testmulti:1"));
+        b1.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b1);
+        Artifact b2 = new Artifact(ArtifactId.fromMvnId("group:testmulti:3"));
+        b2.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:tgtart:1");
+        result.getBundles().add(b2);
+        Artifact b3 = new Artifact(ArtifactId.fromMvnId("group:someart:1.2.3"));
+        b3.getMetadata().put(FeatureConstants.ARTIFACT_ATTR_ORIGINAL_FEATURE, "g:a:2");
+        b3.setStartOrder(4);
+        result.getBundles().add(b3);
+
         equals(result, assembled);
     }
 


### PR DESCRIPTION
When merging artifacts/bundles, they need to be selected from a provided
override list if the artifact versions are not the same. The list has
the following syntax:

*  `groupid1:artifactid1:<resolution>`
*  `groupid2:artifactid2:<resolution>`

To apply the same override rule for all clashes, a wildcard using '*' for
groupID and artifactID can be used:

*  `*:*:<resolution>`

means always select the same resolution in case of a clash.

Where `<resolution>` is one of the following:
*  `ALL` - select all the artifacts
*  `HIGHEST` - select only the artifact with the highest version number
*  `LATEST` - select only the artifact provided latest
*  `<version>` - select this specific version
When comparing version numbers these are converted to OSGi version
numbers and the OSGi version number ordering is applied.

When merging includes, artifacts specified in the target feature
override all artifacts with the same group ID and artifact ID in the
included feature.
Both the included as well the target feature can have multiple artifacts
with the same group ID and artifact ID but different versions.