### PR TITLE
Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/feature/Bundles.java
+++ b/src/main/java/org/apache/sling/feature/Bundles.java
@@ -42,7 +42,7 @@ public class Bundles extends Artifacts {
 
             @Override
             public int compare(final Integer o1, final Integer o2) {
-                if ( o1 == o2 ) {
+                if ( o1.equals(o2) ) {
                     return 0;
                 }
                 if ( o1 == 0 ) {


### PR DESCRIPTION
This fixes 1 Sonarqube violation of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AWolvFAZ7getyiJUvV3-&resolved=false&rules=squid%3AS4973&types=BUG

Jira Ticket:
https://issues.apache.org/jira/browse/SLING-8825