### PR TITLE
SLING-9752 Concurrent Modification Exception when PostProcessor changes extensions

### DIFF
--- a/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
+++ b/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
@@ -668,8 +668,10 @@ class BuilderUtil {
                 }
             }
         }
+
         // post processing
-        for(final Extension ext : target.getExtensions()) {
+        // Make a defensive copy of the extensions, as the handlers may modify the extensions on the target
+        for(final Extension ext : new ArrayList<>(target.getExtensions())) {
             for(final PostProcessHandler ppe : context.getPostProcessExtensions()) {
                 ppe.postProcess(new HandlerContextImpl(context, ppe), target, ext);
             }


### PR DESCRIPTION
Create a defensive copy instead.
Unit test included.