### PR TITLE
SLING-9860 When merging artifacts with the ALL strategy, incorrect feature-origin metadata is recorded

### DIFF
--- a/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
+++ b/src/main/java/org/apache/sling/feature/builder/BuilderUtil.java
@@ -241,7 +241,7 @@ class BuilderUtil {
                     String rule = override.getVersion();
 
                     if (BuilderContext.VERSION_OVERRIDE_ALL.equalsIgnoreCase(rule)) {
-                        result.add(addFeatureOrigin(fromTarget, source, fromSource, fromTarget));
+                        result.add(fromTarget);
                         result.add(fromSource);
                     } else if (BuilderContext.VERSION_OVERRIDE_HIGHEST.equalsIgnoreCase(rule)) {
                         Version a1v = fromTarget.getId().getOSGiVersion();

--- a/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
+++ b/src/test/java/org/apache/sling/feature/builder/FeatureBuilderTest.java
@@ -230,10 +230,8 @@ public class FeatureBuilderTest {
 
         ab = new Feature(ArtifactId.fromMvnId("g:ab:1"));
         for (Artifact bundle : a.getBundles()) {
-            ab.getBundles()
-                    .add(BuilderUtilTest.createBundle(bundle.getId().toMvnId(), bundle.getStartOrder(),
-                            new AbstractMap.SimpleEntry<>(Artifact.KEY_FEATURE_ORIGINS,
-                                    a.getId() + "," + b.getId())));
+            ab.getBundles().add(BuilderUtilTest.createBundle(bundle.getId().toMvnId(), bundle.getStartOrder(),
+                    new AbstractMap.SimpleEntry<>(Artifact.KEY_FEATURE_ORIGINS, a.getId().toMvnId())));
         }
         for (Artifact bundle : b.getBundles()) {
             ab.getBundles().add(BuilderUtilTest.createBundle(bundle.getId().toMvnId(), bundle.getStartOrder(),


### PR DESCRIPTION
When merging with the ALL strategy, don't add the feature-origins from the
source feature to the existing artifacts in the target feature.